### PR TITLE
added sources and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+$(CC) = gcc
+LIBS = -ldb
+CFLAGS = -Wall
+TARGET = postfix-stats-get
+PREFIX = /usr
+
+all: $(TARGET)
+
+$(TARGET):
+	$(CC) -DLINUX -o $(TARGET) $(TARGET).c $(CFLAGS) $(LIBS)
+
+install:
+	install -Dm755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/postfix-stats-get
+
+uninstall:
+	-rm -f $(DESTDIR)$(PREFIX)/bin/postfix-stats-get
+
+clean:
+	rm -f *.o  postfix-stats-get
+
+.PHONY: all install uninstall clean

--- a/postfix-stats-get.c
+++ b/postfix-stats-get.c
@@ -1,0 +1,70 @@
+/*
+ * $jwk: postfix-stats-get.c,v 1.6 2022/09/10 15:31:25 jwk Exp $
+ *
+ * Copyright (c) 2004 by Joel Knight (www.packetmischief.ca)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * [2004.09.21]
+ */
+
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#ifdef LINUX
+#include <db_185.h>
+#else
+#include <db.h>
+#endif
+
+#define DBFILE "/tmp/postfix-stats.db"
+
+int main(int argc, char *argv[])
+{
+	DB *db = NULL;
+	DBT key, value;
+
+	if (argc == 1)
+		exit(1);
+
+	if ((db = dbopen(DBFILE, O_RDONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH,
+			DB_HASH, NULL)) == NULL) {
+		perror("Couldn't open dbfile");
+		return (1);
+	}
+
+	memset(&key, 0, sizeof(key));
+	memset(&value, 0, sizeof(value));
+	key.data = (u_char *)argv[1];
+	key.size = strlen(argv[1]);
+	if (db->get(db, &key, &value, 0)) {
+		printf("No such key \"%s\"\n", (char *)key.data);
+		return (1);
+	}
+
+	printf("%d\n", atoi(value.data));
+
+	db->close(db);
+	return (0);
+}

--- a/update-mailstats.pl
+++ b/update-mailstats.pl
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+#
+# $jwk: update-mailstats.pl,v 1.4 2007/05/30 01:28:33 jwk Exp $
+#
+# Copyright 2006-2007 Joel Knight
+# Copyright Craig Sanders 1999
+#
+# this script is licensed under the terms of the GNU GPL.
+#
+#
+# [2006.11.12]
+
+
+use DB_File;
+use File::Tail;
+$debug = 0;
+
+$mail_log = '/var/log/messages';
+$stats_file = '/tmp/postfix-stats.db';
+
+
+$db = tie(%stats, "DB_File", "$stats_file", O_CREAT|O_RDWR, 0644, $DB_HASH) 
+	|| die ("Cannot open $stats_file");
+
+my $logref = tie(*LOG, "File::Tail", ( name=>$mail_log, debug=>$debug ));
+
+#  taken from perlmonks.com - http://www.perlmonks.org/index.pl?node_id=131513
+close STDIN;
+close STDOUT;
+close STDERR;
+if (open(DEVTTY, "/dev/tty")) {
+	ioctl DEVTTY, 0x20007471, 0;
+	close DEVTTY;
+}
+open STDIN, "</dev/null";
+open STDOUT, ">/dev/null";
+open STDERR, ">&STDOUT";
+fork && exit;
+
+foreach (keys %stats) {
+	$stats{$_} = 0;
+}
+$db->sync;
+
+while (<LOG>) {
+	if (/status=sent/) {
+		next unless (/ postfix\//);
+		if (/relay=([^,]+)/o) {
+			$relay = $1;
+		} 
+		if ($relay !~ /\[/o ) {
+			$stats{"sent:$relay"} += 1;
+		} else {
+			$stats{"sent:smtp"} += 1;
+		} 
+	} elsif (/status=bounced.+said: (\d)\d\d/) {
+		$stats{"smtp:$1xx"} += 1;
+	} elsif (/smtpd.*client=/) {
+		$stats{"recv:smtp"} += 1;
+	} elsif (/pickup.*(sender|uid)=/) {
+		$stats{"recv:local"} += 1;
+	} elsif (/NOQUEUE: reject.+\]: (\d)\d\d/) {
+		$stats{"smtpd:$1xx"} += 1;
+	}
+	$db->sync;
+} 
+
+$db->sync;
+untie $logref;
+untie %stats;
+


### PR DESCRIPTION
postfix-stats-get.c : main program used to extract data from a Berkely DB database file and expose the info to Net-SNMP.

The Berkley DB file is hardcoded in the include:

   #define DBFILE "/tmp/postfix-stats.db"

update-mailstats.pl : perl script that looks for postfix logs and put data in the Berkley DB database.